### PR TITLE
New Extensions

### DIFF
--- a/Carvana.Results/Extensions/FailureResultExtensions.cs
+++ b/Carvana.Results/Extensions/FailureResultExtensions.cs
@@ -49,23 +49,45 @@ namespace Carvana
             return result;
         }
 
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result> OnFailure(this Task<Result> asyncResult, Action onFailure)
+        public static async Task<Result> OnFailureSync(this Task<Result> asyncResult, Action onFailure)
+        {
+            Result result = await asyncResult;
+            if (result.Failed())
+                onFailure();
+            return result;
+        }
         
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result> OnFailure(this Task<Result> asyncResult, Action<Result> onFailure)
+        public static async Task<Result> OnFailureSync(this Task<Result> asyncResult, Action<Result> onFailure)
+        {
+            Result result = await asyncResult;
+            if (result.Failed())
+                onFailure(result);
+            return result;
+        }
+        
+        public static async Task<Result<T>> OnFailureSync<T>(this Task<Result<T>> asyncResult, Action onFailure)
+        {
+            Result<T> result = await asyncResult;
+            if (result.Failed())
+                onFailure();
+            return result;
+        }
 
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */ 
-        // public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> asyncResult, Action onFailure)
-
-        /* Do NOT make an extension method with this signature. It causes massive ambiguity with tasks. */
-        // public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> asyncResult, Action<T> onFailure)
+        public static async Task<Result<T>> OnFailureSync<T>(this Task<Result<T>> asyncResult, Action<Result> onFailure)
+        {
+            Result<T> result = await asyncResult;
+            if (result.Failed())
+                onFailure(result);
+            return result;
+        }
         
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> asyncResult, Action<Result> onFailure)
-        
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> asyncResult, Action<Result<T>> onFailure)
+        public static async Task<Result<T>> OnFailureSync<T>(this Task<Result<T>> asyncResult, Action<Result<T>> onFailure)
+        {
+            Result<T> result = await asyncResult;
+            if (result.Failed())
+                onFailure(result);
+            return result;
+        }
 
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Func<Result, Task> onFailureAsync)
         {

--- a/Carvana.Results/Extensions/SuccessResultExtensions.cs
+++ b/Carvana.Results/Extensions/SuccessResultExtensions.cs
@@ -20,24 +20,30 @@ namespace Carvana
                 onSuccess(result.Content);
             return result;
         }
-        
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result> OnSuccess(this Task<Result> asyncResult, Action onSuccess)
-        
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result> OnSuccess(this Task<Result> asyncResult, Action<Result> onSuccess)
 
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */ 
-        // public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> asyncResult, Action onSuccess)
+        public static async Task<Result> OnSuccessSync(this Task<Result> asyncResult, Action onSuccess)
+        {
+            Result result = await asyncResult;
+            if (result.Succeeded())
+                onSuccess();
+            return result;
+        }
 
-        /* Do NOT make an extension method with this signature. It causes massive ambiguity with tasks. */
-        // public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> asyncResult, Action<T> onSuccess)
-        
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> asyncResult, Action<Result> onSuccess)
-        
-        /* Do NOT make an extension method with this signature. It causes ambiguity with tasks. */
-        // public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> asyncResult, Action<Result<T>> onSuccess)
+        public static async Task<Result<T>> OnSuccessSync<T>(this Task<Result<T>> asyncResult, Action onSuccess)
+        {
+            Result<T> result = await asyncResult;
+            if (result.Succeeded())
+                onSuccess();
+            return result;
+        }
+
+        public static async Task<Result<T>> OnSuccessSync<T>(this Task<Result<T>> asyncResult, Action<T> onSuccess)
+        {
+            Result<T> result = await asyncResult;
+            if (result.Succeeded())
+                onSuccess(result.Content);
+            return result;
+        }
 
         public static async Task<Result<T>> OnSuccess<T>(this Result<T> result, Func<Task> onSuccessAsync)
         {


### PR DESCRIPTION
In order to retain the previous functionality, I have implemented the previously removed calls with a different signature.

We already have these extensions in a few of our projects, but this should give us a full set and allow us to remove those additional extensions.