### PR TITLE
Added Developer Safety Measure Extensions

### DIFF
--- a/Carvana.Results/Extensions/SuccessResultExtensions.cs
+++ b/Carvana.Results/Extensions/SuccessResultExtensions.cs
@@ -7,6 +7,9 @@ namespace Carvana
     [DebuggerNonUserCode]
     public static class SuccessResultExtensions
     {
+        private const string NestedResultWarning = "You are nesting Result objects. This is not the correct overload. Use .OnSuccess() instead.";
+        private const string NestedResultErrorPrefix = "Developer error. You are nesting result objects. ";
+
         public static Result OnSuccess(this Result result, Action onSuccess)
         {
             if (result.Succeeded())
@@ -43,6 +46,14 @@ namespace Carvana
             if (result.Succeeded())
                 onSuccess(result.Content);
             return result;
+        }
+
+        [Obsolete(NestedResultWarning)]
+        public static Task<Result<T>> OnSuccessSync<T>(this Task<Result<T>> asyncResult, Action<Result> onSuccess)
+        {
+            throw new ArgumentException(NestedResultErrorPrefix +
+                "It appears that you are trying to execute a method that returns 'Result', but this extension is only valid for methods returning 'T'. " +
+                "You should use '.OnSuccess()' or '.OnSuccessSync()' here instead.");
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Result<T> result, Func<Task> onSuccessAsync)
@@ -185,12 +196,28 @@ namespace Carvana
                 : Result<TOutput>.Errored(input.Status, input.ErrorMessage);
         }
 
+        [Obsolete(NestedResultWarning)]
+        public static Task<Result<Result>> Then<TInput>(this Task<Result<TInput>> asyncInput, Func<TInput, Result> getOutput)
+        {
+            throw new ArgumentException(NestedResultErrorPrefix +
+                "It appears that you are trying to execute a method that returns 'Result', but this extension is only valid for methods returning 'Result<T>'. " +
+                "You should use '.OnSuccess()' or '.OnSuccessSync()' here instead.");
+        }
+
         public static async Task<Result<TOutput>> Then<TInput, TOutput>(this Task<Result<TInput>> asyncInput, Func<TInput, Task<TOutput>> getOutputAsync)
         {
             Result<TInput> input = await asyncInput;
             return input.Succeeded()
                 ? Result.Success(await getOutputAsync(input.Content))
                 : Result<TOutput>.Errored(input.Status, input.ErrorMessage);
+        }
+
+        [Obsolete(NestedResultWarning)]
+        public static Task<Result<Result>> Then<TInput>(this Task<Result<TInput>> asyncInput, Func<TInput, Task<Result>> getOutputAsync)
+        {
+            throw new ArgumentException(NestedResultErrorPrefix +
+                "It appears that you are trying to execute a method that returns 'Task<Result>', but this extension is only valid for methods returning 'Task<Result<T>>'. " +
+                "You should use '.OnSuccess()' or '.OnSuccessSync()' here instead.");
         }
 
         public static async Task<Result<TOutput>> Then<TInput, TOutput>(this Task<Result<TInput>> asyncInput,

--- a/Carvana.Results/Result.cs
+++ b/Carvana.Results/Result.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 
 namespace Carvana
@@ -15,7 +16,8 @@ namespace Carvana
         public Result(ResultStatus status, string errorMessage)
             : base(status, errorMessage) { }
 
-        internal Result(ResultStatus status, string errorMessage, T content)
+        [Obsolete("Do not use this constructor. It is purely for serialization purposes.")]
+        public Result(ResultStatus status, string errorMessage, T content)
             : base(status, errorMessage)
         {
             Content = content;
@@ -27,6 +29,7 @@ namespace Carvana
         public new static Result<T> Errored(ResultStatus status, string errorMessage) => new Result<T>(status, errorMessage);
         public static Result<T> NotFound(string errorMessage) => new Result<T>(ResultStatus.MissingResource, errorMessage);
         public new static Result<T> InvalidRequest(string errorMessage) => new Result<T>(ResultStatus.InvalidRequest, errorMessage);
+        public new static Result<T> MissingResource(string errorMessage) => new Result<T>(ResultStatus.MissingResource, errorMessage);
     }
 
     [DebuggerNonUserCode]

--- a/Carvana.Results/Result.cs
+++ b/Carvana.Results/Result.cs
@@ -27,8 +27,8 @@ namespace Carvana
 
         public static Result<T> Success(T content) => new Result<T>(content);
         public new static Result<T> Errored(ResultStatus status, string errorMessage) => new Result<T>(status, errorMessage);
-        public static Result<T> NotFound(string errorMessage) => new Result<T>(ResultStatus.MissingResource, errorMessage);
         public new static Result<T> InvalidRequest(string errorMessage) => new Result<T>(ResultStatus.InvalidRequest, errorMessage);
+        public new static Result<T> NotFound(string errorMessage) => new Result<T>(ResultStatus.MissingResource, errorMessage);
         public new static Result<T> MissingResource(string errorMessage) => new Result<T>(ResultStatus.MissingResource, errorMessage);
     }
 
@@ -54,6 +54,7 @@ namespace Carvana
         public static Result Success() => new Result<string>("No Content");
         public static Result Errored(ResultStatus status, string errorMessage) => new Result<string>(status, errorMessage, default(string));
         public static Result InvalidRequest(string errorMessage) => new Result<string>(ResultStatus.InvalidRequest, errorMessage, default(string));
+        public static Result NotFound(string errorMessage) => new Result<string>(ResultStatus.MissingResource, errorMessage, default(string));
         public static Result MissingResource(string errorMessage) => new Result<string>(ResultStatus.MissingResource, errorMessage, default(string));
         public static Result<T> Success<T>(T content) => new Result<T>(content);
         public static Result<T> Errored<T>(ResultStatus status, string errorMessage) => new Result<T>(status, errorMessage);


### PR DESCRIPTION
Added an extra static instantiation method on Result<T> to mirror what we have on the base object.
Added some obsolete method signatures that can help prevent invalid extension usage.
